### PR TITLE
News landing pages

### DIFF
--- a/css/base/elements.css
+++ b/css/base/elements.css
@@ -113,3 +113,27 @@ h5 a,
           line-clamp: 2;
   -webkit-box-orient: vertical;
 }
+
+.header-overline {
+  font-family: var(--font-stratum);
+  font-size: 1rem;
+  line-height: 125%;
+}
+.smaller {
+  font-size: 0.75em;
+  line-height: 1.4em;
+}
+.object-fit-cover img {
+  object-fit: cover;
+}
+.image-w-100 img {
+  width: 100%;
+}
+a.arrow-link::before {
+  content : "";
+  position: absolute;
+  bottom  : 0;
+  height  : 1px;
+  background: var(--color-coastline-100) !important;
+  width: 50%;
+}

--- a/css/component/view.css
+++ b/css/component/view.css
@@ -1,9 +1,3 @@
-.header-overline {
-  font-family: var(--font-stratum);
-  font-size: 1rem;
-  line-height: 125%;
-}
-
 /* News views page */
 .node--type-news.node--view-mode-teaser {
   box-sizing: content-box;

--- a/templates/content/node--news.html.twig
+++ b/templates/content/node--news.html.twig
@@ -76,37 +76,54 @@
   not node.isPublished() ? 'node--unpublished',
   view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
   'px-4',
+  'my-2',
 ] %}
 <article{{attributes.addClass(classes)}}>
+  <div class="row">
+    <div class="d-none d-md-inline-block col-md-5 pb-5 image-w-100">
+      {{ content.field_news_image }}
+      <div class="color-grey-600 smaller">
+        {{ content.field_news_image_caption }}
+      </div>
 
-  {{ title_prefix }}
-  {% if label %}
-    <div class="header-overline color-grey-600 text-uppercase smaller">
-      {{ content.field_branch }}
+      {# border below image for sm display #}
+      <div class="d-md-none border-bottom mb-5"></div>
     </div>
-    <h2{{title_attributes.addClass('h1','text-uppercase','my-1','mb-0')}}>
-      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-    </h2>
-    <div class="small color-grey-600 fst-italic mb-4">
-      {{ content.field_date }}
+
+    <div class="col-12 col-md-7">
+      {{ title_prefix }}
+      {% if label %}
+        <div class="header-overline color-grey-600 text-uppercase smaller">
+          {{ content.field_branch }}
+        </div>
+        <h2{{title_attributes.addClass('h1','text-uppercase','my-1','mb-0')}}>
+          <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        </h2>
+        <div class="small color-grey-600 fst-italic mb-4-5">
+          {{ content.field_date }}
+        </div>
+      {% endif %}
+      {{ title_suffix }}
+
+      {# border below title for md display #}
+      <div class="d-none d-md-block border-bottom mb-5"></div>
+
+      <div class="d-md-none pb-5 border-bottom mb-5 image-w-100">
+        {{ content.field_news_image }}
+        <div class="color-grey-600 smaller">
+          {{ content.field_news_image_caption }}
+        </div>
+      </div>
+
+      <div class="mb-2-5 mb-md-5">
+        {{ content.body }}
+      </div>
+
+      <div>
+        <a class="arrow-link" href="/news">
+          <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All OSU Libraries News</a>
+      </div>
     </div>
-  {% endif %}
-  {{ title_suffix }}
-
-  <div class="pb-5 border-bottom mb-5 image-w-100">
-    {{ content.field_news_image }}
-    <div class="color-grey-600 smaller">
-      {{ content.field_news_image_caption }}
-    </div>
-  </div>
-
-  <div>
-    {{ content.body }}
-  </div>
-
-  <div>
-    <a class="arrow-link" href="/news">
-      <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All OSU Libraries News</a>
   </div>
 
   {% if display_submitted %}

--- a/templates/content/node--news.html.twig
+++ b/templates/content/node--news.html.twig
@@ -1,0 +1,126 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [
+  'node',
+  'node--type-' ~ node.bundle|clean_class,
+  node.isPromoted() ? 'node--promoted',
+  node.isSticky() ? 'node--sticky',
+  not node.isPublished() ? 'node--unpublished',
+  view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  'px-4',
+] %}
+<article{{attributes.addClass(classes)}}>
+
+  {{ title_prefix }}
+  {% if label %}
+    <div class="header-overline color-grey-600 text-uppercase smaller">
+      {{ content.field_branch }}
+    </div>
+    <h2{{title_attributes.addClass('h1','text-uppercase','my-1','mb-0')}}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+    <div class="small color-grey-600 fst-italic mb-4">
+      {{ content.field_date }}
+    </div>
+  {% endif %}
+  {{ title_suffix }}
+
+  <div class="pb-5 border-bottom mb-5 image-w-100">
+    {{ content.field_news_image }}
+    <div class="color-grey-600 smaller">
+      {{ content.field_news_image_caption }}
+    </div>
+  </div>
+
+  <div>
+    {{ content.body }}
+  </div>
+
+  <div>
+    <a class="arrow-link" href="/news">
+      <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All OSU Libraries News</a>
+  </div>
+
+  {% if display_submitted %}
+    <footer>
+      {{ author_picture }}
+      <div{{author_attributes.addClass('fst-italic','text-align-center')}}>
+        {% trans %}
+        By
+        {{ author_name }}
+        on
+        {{ date }}
+        {% endtrans %}
+        {{ metadata }}
+      </div>
+    </footer>
+  {% endif %}
+</article>

--- a/templates/content/node--news.html.twig
+++ b/templates/content/node--news.html.twig
@@ -115,9 +115,15 @@
       </div>
       <div class="mb-2-5 mb-md-5">
         {{ content.body }}</div>
-      <div>
-        <a class="arrow-link" href="/news">
+      <div class="mb-2-5 row">
+        <a class="arrow-link col-12 col-sm-5" href="/news">
           <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All OSU Libraries News</a>
+        {% if node.field_branch.value != 'osu_libraries' %}
+          <a class="arrow-link col-12 col-sm-5" href="/news?field_branch_value={{ node.field_branch.value }}">
+            <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All
+            {{ node.field_branch.value|capitalize }}
+            News</a>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/templates/content/node--news.html.twig
+++ b/templates/content/node--news.html.twig
@@ -78,19 +78,22 @@
   'px-4',
   'my-2',
 ] %}
+{% set has_image = node.field_news_image is not empty %}
 <article{{attributes.addClass(classes)}}>
   <div class="row">
-    <div class="d-none d-md-inline-block col-md-5 pb-5 image-w-100">
-      {{ content.field_news_image }}
-      <div class="color-grey-600 smaller">
-        {{ content.field_news_image_caption }}
+    {% if has_image %}
+      <div class="d-none d-md-inline-block col-md-5 pb-5 image-w-100">
+        {{ content.field_news_image }}
+        <div class="color-grey-600 smaller">
+          {{ content.field_news_image_caption }}
+        </div>
+
+        {# border below image for sm display #}
+        <div class="d-md-none border-bottom mb-5"></div>
       </div>
+    {% endif %}
 
-      {# border below image for sm display #}
-      <div class="d-md-none border-bottom mb-5"></div>
-    </div>
-
-    <div class="col-12 col-md-7">
+    <div class="col-12 {{ has_image ? 'col-md-7' : 'col-md-12' }} col-lg-7">
       {{ title_prefix }}
       {% if label %}
         <div class="header-overline color-grey-600 text-uppercase smaller">
@@ -103,41 +106,30 @@
           {{ content.field_date }}
         </div>
       {% endif %}
-      {{ title_suffix }}
-
-      {# border below title for md display #}
-      <div class="d-none d-md-block border-bottom mb-5"></div>
-
+      {{ title_suffix }}{# border below title for md display #}<div class="d-none d-md-block border-bottom mb-5"></div>
       <div class="d-md-none pb-5 border-bottom mb-5 image-w-100">
         {{ content.field_news_image }}
         <div class="color-grey-600 smaller">
           {{ content.field_news_image_caption }}
         </div>
       </div>
-
       <div class="mb-2-5 mb-md-5">
-        {{ content.body }}
-      </div>
-
+        {{ content.body }}</div>
       <div>
         <a class="arrow-link" href="/news">
           <i class="fa-solid fa-circle-arrow-right me-2 color-beaver-dark"></i>All OSU Libraries News</a>
       </div>
     </div>
   </div>
-
   {% if display_submitted %}
-    <footer>
-      {{ author_picture }}
-      <div{{author_attributes.addClass('fst-italic','text-align-center')}}>
+    <footer>{{ author_picture }}<div{{author_attributes.addClass('fst-italic','text-align-center')}}>
         {% trans %}
         By
         {{ author_name }}
         on
         {{ date }}
         {% endtrans %}
-        {{ metadata }}
-      </div>
+        {{ metadata }}</div>
     </footer>
   {% endif %}
 </article>

--- a/templates/node/node--news--news-featured.html.twig
+++ b/templates/node/node--news--news-featured.html.twig
@@ -96,10 +96,6 @@
         </h2>
       {% endif %}
       {{ title_suffix }}
-
-      <span class="color-grey-700">
-        {{ content.body }}
-      </span>
     </div>
   </div>
 </article>


### PR DESCRIPTION
Images might be a little large, they're pretty much free to be full size. We can sort out sizing later.
And the header is in experimentation, this PR shouldn't change it. That was done w/ block layout

![Screen Shot 2024-09-19 at 13 57 27](https://github.com/user-attachments/assets/a080595c-08d5-497c-89e1-e652838ea92d)

![Screen Shot 2024-09-19 at 13 57 20](https://github.com/user-attachments/assets/c9d5ddff-c1bb-4be8-a2f4-81ee2e1833f8)

![Screen Shot 2024-09-19 at 13 57 05](https://github.com/user-attachments/assets/a1e53170-047f-469a-9f67-9c53ffcbbdcd)
![Screen Shot 2024-09-19 at 13 57 11](https://github.com/user-attachments/assets/cf327227-ca4a-454c-b953-5c486e898bfe)
