### PR TITLE
Add left sidebar region as 2-col

### DIFF
--- a/osulp.info.yml
+++ b/osulp.info.yml
@@ -18,7 +18,8 @@ regions:
   help: Help
   page_top: Page Top
   content: Content
-  sidebar: Sidebar
+  left_sidebar: Left Sidebar
+  right_sidebar: Right Sidebar
   page_bottom: Page Bottom
   pre_footer: Full width above the Footer
   footer: Footer

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -1,0 +1,101 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<div class="layout-container min-vh-100 d-flex flex-column">
+
+  <header class="container-fluid osu-bg-page-alt-1 g-0" role="banner">
+    {{ page.header }}
+  </header>
+
+  {{ page.primary_menu }}
+  {{ page.full_top }}
+  {{ page.breadcrumb }}
+  {{ page.highlighted }}
+  {{ page.help }}
+
+  {% set left_page_sidebar_content = page.left_sidebar|render|striptags('<img><video><drupal-render-placeholder>')|trim is not empty %}
+  {% set right_page_sidebar_content = page.right_sidebar|render|striptags('<img><video><drupal-render-placeholder>')|trim is not empty %}
+  {# Do we have at least one sidebar? #}
+  {% set one_sidebar_set = left_page_sidebar_content or right_page_sidebar_content %}
+  {# Do we have TWO sidebars? #}
+  {% set two_sidebar_set = left_page_sidebar_content and right_page_sidebar_content %}
+
+  {% set num_main_lg_cols = two_sidebar_set ? 8 : one_sidebar_set ? 10 : 12 %}
+
+  {% set content_classes = [
+    'layout-content',
+    "col-12 col-lg-" ~ num_main_lg_cols,
+  ] %}
+  <div class="flex-fill position-relative">
+    <main class="d-flex flex-wrap flex-fill gx-3 gx-lg-0" role="main">
+      <a id="main-content" tabindex="-1"></a>
+
+      {% if left_page_sidebar_content %}
+        <aside class="layout-sidebar px-4 px-lg-2 px-xxl-2 d-none d-lg-block col-lg-2 flex-fill" role="complementary">
+          {{ page.left_sidebar }}
+        </aside>
+      {% endif %}
+
+      {# link is in html.html.twig #}
+      <div{{content_attributes.addClass(content_classes)}}>
+        {{ page.content }}
+      </div>
+
+      {% if right_page_sidebar_content %}
+        <aside class="layout-sidebar px-4 px-lg-2 px-xxl-2 d-none d-lg-block col-lg-2 flex-fill" role="complementary">
+          {{ page.right_sidebar }}
+        </aside>
+      {% endif %}
+    </main>
+  </div>
+  {{ page.pre_footer }}
+
+  <footer class="container-fluid g-0 mt-auto" role="contentinfo">
+    {{ page.footer }}
+  </footer>
+
+
+</div>
+{# /.layout-container #}

--- a/templates/layout/region--left-sidebar.html.twig
+++ b/templates/layout/region--left-sidebar.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{% set region_id = 'madrone-' ~ region|clean_class ~ '-container' %}
+{% set region_class = [
+  'madrone-' ~ region|clean_class
+] %}
+{% if content %}
+  <div{{attributes.setAttribute('id',region_id).addClass(region_class)}}>
+    {{ content }}
+  </div>
+{% endif %}

--- a/templates/layout/region--right-sidebar.html.twig
+++ b/templates/layout/region--right-sidebar.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{% set region_id = 'madrone-' ~ region|clean_class ~ '-container' %}
+{% set region_class = [
+  'madrone-' ~ region|clean_class
+] %}
+{% if content %}
+  <div{{attributes.setAttribute('id',region_id).addClass(region_class)}}>
+    {{ content }}
+  </div>
+{% endif %}

--- a/templates/navigation/menu--left-sidebar.html.twig
+++ b/templates/navigation/menu--left-sidebar.html.twig
@@ -1,0 +1,72 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+{#
+We call a macro which calls itself to render the full tree.
+@see https://twig.symfony.com/doc/1.x/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes.removeAttribute('region'), 0, menu_name) }}
+
+{% macro menu_links(items, attributes, menu_level, menu_name) %}
+  {% import _self as menus %}
+  {% set menu_classes = [
+    'menu',
+    'menu--' ~ menu_name|clean_class,
+    'nav',
+    'nav-pills',
+    'flex-column',
+    'osu-nav-link-hover--dark'
+  ] %}
+  {% set submenu_classes = [
+    'menu--' ~ menu_name|clean_class ~ '__submenu'
+  ] %}
+  {% set menu_levels = [
+    'menu--level-' ~ (menu_level + 1),
+    'nav'
+  ] %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass(menu_classes, menu_levels) }}>
+    {% else %}
+      <ul{{ attributes.removeCLass(menu_classes).addClass(submenu_classes, menu_levels) }}>
+    {% endif %}
+    {% set attributes = attributes.removeClass(menu_levels) %}
+    {% for item in items %}
+      {% set li_classes = [
+        item.in_active_trail ? 'nav-item active' : 'nav-item',
+      ] %}
+      {% set link_classes = [
+        item.in_active_trail ? 'nav-link active' : 'nav-link',
+      ] %}
+      <li{{ item.attributes.addCLass(li_classes) }}>
+        {{ link(item.title, item.url, item.attributes.addClass(link_classes).removeClass(li_classes)) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_name) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    {% if menu_level == 0 %}
+      </ul>
+    {% else %}
+      </ul>
+    {% endif %}
+  {% endif %}
+{% endmacro %}

--- a/templates/navigation/menu--right-sidebar.html.twig
+++ b/templates/navigation/menu--right-sidebar.html.twig
@@ -1,0 +1,72 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+{#
+We call a macro which calls itself to render the full tree.
+@see https://twig.symfony.com/doc/1.x/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes.removeAttribute('region'), 0, menu_name) }}
+
+{% macro menu_links(items, attributes, menu_level, menu_name) %}
+  {% import _self as menus %}
+  {% set menu_classes = [
+    'menu',
+    'menu--' ~ menu_name|clean_class,
+    'nav',
+    'nav-pills',
+    'flex-column',
+    'osu-nav-link-hover--dark'
+  ] %}
+  {% set submenu_classes = [
+    'menu--' ~ menu_name|clean_class ~ '__submenu'
+  ] %}
+  {% set menu_levels = [
+    'menu--level-' ~ (menu_level + 1),
+    'nav'
+  ] %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass(menu_classes, menu_levels) }}>
+    {% else %}
+      <ul{{ attributes.removeCLass(menu_classes).addClass(submenu_classes, menu_levels) }}>
+    {% endif %}
+    {% set attributes = attributes.removeClass(menu_levels) %}
+    {% for item in items %}
+      {% set li_classes = [
+        item.in_active_trail ? 'nav-item active' : 'nav-item',
+      ] %}
+      {% set link_classes = [
+        item.in_active_trail ? 'nav-link active' : 'nav-link',
+      ] %}
+      <li{{ item.attributes.addCLass(li_classes) }}>
+        {{ link(item.title, item.url, item.attributes.addClass(link_classes).removeClass(li_classes)) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1, menu_name) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    {% if menu_level == 0 %}
+      </ul>
+    {% else %}
+      </ul>
+    {% endif %}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
Keeps right sidebar as an option.
Each sidebar will use 2 bootstrap columns and the main content will shrink accordingly
Below the `lg` breakpoint the sidebars will disappear and the main content will grow to 12 columns