### PR TITLE
Align news articles with and without images

### DIFF
--- a/templates/node/node--news--teaser.html.twig
+++ b/templates/node/node--news--teaser.html.twig
@@ -79,7 +79,7 @@
   'py-3',
 ] %}
 {% set has_image = node.field_news_image is not empty %}
-{% set col_class = has_image ? 'col-md-9 col-lg-6' : 'col-md-9 offset-md-1' %}
+{% set col_class = has_image ? 'col-md-9' : 'col-md-9 offset-md-3' %}
 
 <article{{attributes.addClass(classes)}}>
   <div class="row">


### PR DESCRIPTION
Fixes osulp/main-site#94

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/5ebf0e1f-7a1f-4027-98be-d569b54b72e3" />
